### PR TITLE
named the return of AllFiles

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -82,9 +82,9 @@ func SourceSize(vs ...interface{}) memory.Bytes {
 func AllFiles(vs ...interface{}) (files []string) {
 	for _, v := range vs {
 		switch v := v.(type) {
-		case []string: // assume we want the size of a list of files
+		case []string:
 			files = append(files, v...)
-		case *packages.Package: // assume we want the size of all files in package directories
+		case *packages.Package:
 			files = append(files, allFiles(v)...)
 		}
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -79,8 +79,7 @@ func SourceSize(vs ...interface{}) memory.Bytes {
 	return memory.Bytes(size)
 }
 
-func AllFiles(vs ...interface{}) []string {
-	var files []string
+func AllFiles(vs ...interface{}) (files []string) {
 	for _, v := range vs {
 		switch v := v.(type) {
 		case []string: // assume we want the size of a list of files


### PR DESCRIPTION
I think it's a good practice to use named returns when returning basic types that could carry any kind of content (e.g. string, int), it's fine not to name the return if it's of type error or a custom struct.