### PR TITLE
graph: clearer node names in generated dot source

### DIFF
--- a/internal/graph/cmd.go
+++ b/internal/graph/cmd.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/google/subcommands"
@@ -141,21 +142,7 @@ type Format interface {
 }
 
 func pkgID(p *pkggraph.Node) string {
-	return escapeID(p.ID)
-}
-
-func escapeID(s string) string {
-	var d []byte
-	for _, r := range s {
-		if 'a' <= r && r <= 'z' {
-			d = append(d, byte(r))
-		} else if 'A' <= r && r <= 'Z' {
-			d = append(d, byte(r))
-		} else if '0' <= r && r <= '9' {
-			d = append(d, byte(r))
-		} else {
-			d = append(d, '_')
-		}
-	}
-	return "n_" + string(d)
+	// Go quoting rules are similar enough to dot quoting.
+	// At least enough similar to quote a Go import path.
+	return strconv.Quote(p.ID)
 }

--- a/internal/graph/dot.go
+++ b/internal/graph/dot.go
@@ -156,7 +156,7 @@ func (ctx *Dot) WriteClusters(graph *pkggraph.Graph) {
 		}
 
 		if print {
-			fmt.Fprintf(ctx.out, "subgraph cluster_%v {\n", escapeID(tree.Path))
+			fmt.Fprintf(ctx.out, "subgraph %q {\n", "cluster_"+tree.Path)
 			if tree.Package != nil {
 				isCluster[tree.Package] = true
 				fmt.Fprintf(ctx.out, "    %v [label=\"\" tooltip=\"%v\" shape=circle %v rank=0];\n", pkgID(p), tree.Path, ctx.colorOf(p))
@@ -181,7 +181,7 @@ func (ctx *Dot) WriteClusters(graph *pkggraph.Graph) {
 			tooltip := src.ID + " -> " + dst.ID
 
 			if isCluster[dst] && !srctree.HasParent(dsttree) {
-				fmt.Fprintf(ctx.out, "    %v -> %v [tooltip=\"%v\" lhead=cluster_%v %v];\n", pkgID(src), dstid, tooltip, dstid, ctx.colorOf(dst))
+				fmt.Fprintf(ctx.out, "    %v -> %v [tooltip=\"%v\" lhead=%q %v];\n", pkgID(src), dstid, tooltip, "cluster_"+dst.ID, ctx.colorOf(dst))
 			} else {
 				fmt.Fprintf(ctx.out, "    %v -> %v [tooltip=\"%v\" %v];\n", pkgID(src), dstid, tooltip, ctx.colorOf(dst))
 			}


### PR DESCRIPTION
Just use the quoted import path of the package as the node name or cluster name.

This makes the dot source more readable as import paths are directly visible.