### PR TITLE
graph: repository and module clustering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/google/subcommands v1.2.0
+	golang.org/x/mod v0.5.1
 	golang.org/x/tools v0.1.9
 )
 
 require (
-	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/internal/cut/cmd.go
+++ b/internal/cut/cmd.go
@@ -76,15 +76,15 @@ func (cmd *Command) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	nodes := map[string]*Node{}
 	nodelist := []*Node{}
 
-	var include func(parent *Node, n *pkggraph.Node)
-	include = func(parent *Node, n *pkggraph.Node) {
+	var include func(parent *Node, n *pkggraph.GraphNode)
+	include = func(parent *Node, n *pkggraph.GraphNode) {
 		if n, ok := nodes[n.ID]; ok {
 			parent.Import(n)
 			return
 		}
 
 		node := &Node{
-			Node: n,
+			GraphNode: n,
 		}
 		nodes[n.ID] = node
 		if _, analyse := graph.Packages[n.ID]; analyse {
@@ -148,7 +148,7 @@ func Reset(stats map[string]*Node) {
 }
 
 func Erase(stat *Node) stat.Stat {
-	cut := stat.Node.Stat
+	cut := stat.Stat
 	for _, imp := range stat.Imports {
 		imp.indegree--
 		if imp.indegree == 0 {
@@ -159,7 +159,7 @@ func Erase(stat *Node) stat.Stat {
 }
 
 type Node struct {
-	*pkggraph.Node
+	*pkggraph.GraphNode
 
 	Cut stat.Stat
 

--- a/internal/cut/cmd.go
+++ b/internal/cut/cmd.go
@@ -76,15 +76,15 @@ func (cmd *Command) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	nodes := map[string]*Node{}
 	nodelist := []*Node{}
 
-	var include func(parent *Node, n *pkggraph.GraphNode)
-	include = func(parent *Node, n *pkggraph.GraphNode) {
+	var include func(parent *Node, n *pkggraph.Node)
+	include = func(parent *Node, n *pkggraph.Node) {
 		if n, ok := nodes[n.ID]; ok {
 			parent.Import(n)
 			return
 		}
 
 		node := &Node{
-			GraphNode: n,
+			Node: n,
 		}
 		nodes[n.ID] = node
 		if _, analyse := graph.Packages[n.ID]; analyse {
@@ -159,7 +159,7 @@ func Erase(stat *Node) stat.Stat {
 }
 
 type Node struct {
-	*pkggraph.GraphNode
+	*pkggraph.Node
 
 	Cut stat.Stat
 

--- a/internal/graph/cmd.go
+++ b/internal/graph/cmd.go
@@ -145,7 +145,7 @@ type Format interface {
 	Write(*pkggraph.Graph) error
 }
 
-func pkgID(p *pkggraph.GraphNode) string {
+func pkgID(p *pkggraph.Node) string {
 	// Go quoting rules are similar enough to dot quoting.
 	// At least enough similar to quote a Go import path.
 	return strconv.Quote(p.ID)

--- a/internal/graph/cmd.go
+++ b/internal/graph/cmd.go
@@ -133,16 +133,19 @@ func (cmd *Command) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	graph := pkggraph.From(result)
-	format.Write(graph)
+	if err := format.Write(graph); err != nil {
+		fmt.Fprintf(os.Stderr, "error building graph: %v\n", err)
+		return subcommands.ExitFailure
+	}
 
 	return subcommands.ExitSuccess
 }
 
 type Format interface {
-	Write(*pkggraph.Graph)
+	Write(*pkggraph.Graph) error
 }
 
-func pkgID(p *pkggraph.Node) string {
+func pkgID(p *pkggraph.GraphNode) string {
 	// Go quoting rules are similar enough to dot quoting.
 	// At least enough similar to quote a Go import path.
 	return strconv.Quote(p.ID)

--- a/internal/graph/digraph.go
+++ b/internal/graph/digraph.go
@@ -15,7 +15,7 @@ type Digraph struct {
 	label *template.Template
 }
 
-func (ctx *Digraph) Label(p *pkggraph.GraphNode) string {
+func (ctx *Digraph) Label(p *pkggraph.Node) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -25,7 +25,7 @@ func (ctx *Digraph) Label(p *pkggraph.GraphNode) string {
 }
 
 func (ctx *Digraph) Write(graph *pkggraph.Graph) error {
-	labelCache := map[*pkggraph.GraphNode]string{}
+	labelCache := map[*pkggraph.Node]string{}
 	for _, node := range graph.Sorted {
 		labelCache[node] = ctx.Label(node)
 	}

--- a/internal/graph/digraph.go
+++ b/internal/graph/digraph.go
@@ -15,7 +15,7 @@ type Digraph struct {
 	label *template.Template
 }
 
-func (ctx *Digraph) Label(p *pkggraph.Node) string {
+func (ctx *Digraph) Label(p *pkggraph.GraphNode) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -24,8 +24,8 @@ func (ctx *Digraph) Label(p *pkggraph.Node) string {
 	return labelText.String()
 }
 
-func (ctx *Digraph) Write(graph *pkggraph.Graph) {
-	labelCache := map[*pkggraph.Node]string{}
+func (ctx *Digraph) Write(graph *pkggraph.Graph) error {
+	labelCache := map[*pkggraph.GraphNode]string{}
 	for _, node := range graph.Sorted {
 		labelCache[node] = ctx.Label(node)
 	}
@@ -36,4 +36,6 @@ func (ctx *Digraph) Write(graph *pkggraph.Graph) {
 		}
 		fmt.Fprintf(ctx.out, "\n")
 	}
+
+	return nil
 }

--- a/internal/graph/dot.go
+++ b/internal/graph/dot.go
@@ -32,7 +32,7 @@ func (ctx *Dot) Label(p *pkggraph.Node) string {
 }
 
 func (ctx *Dot) ClusterLabel(tree *pkggraph.Tree, parentPrinted bool) string {
-	var suffix = ""
+	suffix := ""
 	if parentPrinted && tree.Parent != nil && tree.Parent.Path != "" {
 		suffix = "./" + strings.TrimPrefix(tree.Path, tree.Parent.Path+"/")
 	}
@@ -44,7 +44,7 @@ func (ctx *Dot) ClusterLabel(tree *pkggraph.Tree, parentPrinted bool) string {
 }
 
 func (ctx *Dot) TreeLabel(tree *pkggraph.Tree, parentPrinted bool) string {
-	var suffix = ""
+	suffix := ""
 	if parentPrinted && tree.Parent != nil && tree.Parent.Path != "" {
 		suffix = strings.TrimPrefix(tree.Path, tree.Parent.Path+"/")
 	}
@@ -122,11 +122,11 @@ func (ctx *Dot) WriteClusters(graph *pkggraph.Graph) {
 	ctx.writeGraphProperties()
 	defer fmt.Fprintf(ctx.out, "}\n")
 
-	var walk func(bool, *pkggraph.Tree)
-	root := graph.Tree()
+	root := graph.Tree(pkggraph.RepoStrategy{})
 	lookup := root.LookupTable()
 	isCluster := map[*pkggraph.Node]bool{}
 
+	var walk func(bool, *pkggraph.Tree)
 	walk = func(parentPrinted bool, tree *pkggraph.Tree) {
 		p := tree.Package
 		if len(tree.Children) == 0 {
@@ -137,9 +137,6 @@ func (ctx *Dot) WriteClusters(graph *pkggraph.Graph) {
 		}
 
 		print := p != nil
-		if p != nil {
-			print = true
-		}
 
 		childPackageCount := 0
 		for _, child := range tree.Children {

--- a/internal/graph/edges.go
+++ b/internal/graph/edges.go
@@ -15,7 +15,7 @@ type Edges struct {
 	label *template.Template
 }
 
-func (ctx *Edges) Label(p *pkggraph.GraphNode) string {
+func (ctx *Edges) Label(p *pkggraph.Node) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -25,7 +25,7 @@ func (ctx *Edges) Label(p *pkggraph.GraphNode) string {
 }
 
 func (ctx *Edges) Write(graph *pkggraph.Graph) error {
-	labelCache := map[*pkggraph.GraphNode]string{}
+	labelCache := map[*pkggraph.Node]string{}
 	for _, node := range graph.Sorted {
 		labelCache[node] = ctx.Label(node)
 	}

--- a/internal/graph/edges.go
+++ b/internal/graph/edges.go
@@ -15,7 +15,7 @@ type Edges struct {
 	label *template.Template
 }
 
-func (ctx *Edges) Label(p *pkggraph.Node) string {
+func (ctx *Edges) Label(p *pkggraph.GraphNode) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -24,8 +24,8 @@ func (ctx *Edges) Label(p *pkggraph.Node) string {
 	return labelText.String()
 }
 
-func (ctx *Edges) Write(graph *pkggraph.Graph) {
-	labelCache := map[*pkggraph.Node]string{}
+func (ctx *Edges) Write(graph *pkggraph.Graph) error {
+	labelCache := map[*pkggraph.GraphNode]string{}
 	for _, node := range graph.Sorted {
 		labelCache[node] = ctx.Label(node)
 	}
@@ -34,4 +34,6 @@ func (ctx *Edges) Write(graph *pkggraph.Graph) {
 			fmt.Fprintf(ctx.out, "%s %s\n", labelCache[node], labelCache[imp])
 		}
 	}
+
+	return nil
 }

--- a/internal/graph/graphml.go
+++ b/internal/graph/graphml.go
@@ -18,7 +18,7 @@ type GraphML struct {
 	label *template.Template
 }
 
-func (ctx *GraphML) Label(p *pkggraph.GraphNode) string {
+func (ctx *GraphML) Label(p *pkggraph.Node) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {

--- a/internal/graph/graphml.go
+++ b/internal/graph/graphml.go
@@ -18,7 +18,7 @@ type GraphML struct {
 	label *template.Template
 }
 
-func (ctx *GraphML) Label(p *pkggraph.Node) string {
+func (ctx *GraphML) Label(p *pkggraph.GraphNode) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -27,7 +27,7 @@ func (ctx *GraphML) Label(p *pkggraph.Node) string {
 	return labelText.String()
 }
 
-func (ctx *GraphML) Write(graph *pkggraph.Graph) {
+func (ctx *GraphML) Write(graph *pkggraph.Graph) error {
 	file := graphml.NewFile()
 	file.Graphs = append(file.Graphs, ctx.ConvertGraph(graph))
 
@@ -43,6 +43,8 @@ func (ctx *GraphML) Write(graph *pkggraph.Graph) {
 	if err != nil {
 		fmt.Fprintf(ctx.err, "failed to output: %v\n", err)
 	}
+
+	return nil
 }
 
 func (ctx *GraphML) ConvertGraph(graph *pkggraph.Graph) *graphml.Graph {

--- a/internal/graph/tgf.go
+++ b/internal/graph/tgf.go
@@ -15,7 +15,7 @@ type TGF struct {
 	label *template.Template
 }
 
-func (ctx *TGF) Label(p *pkggraph.GraphNode) string {
+func (ctx *TGF) Label(p *pkggraph.Node) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -25,7 +25,7 @@ func (ctx *TGF) Label(p *pkggraph.GraphNode) string {
 }
 
 func (ctx *TGF) Write(graph *pkggraph.Graph) error {
-	indexCache := map[*pkggraph.GraphNode]int64{}
+	indexCache := map[*pkggraph.Node]int64{}
 	for i, node := range graph.Sorted {
 		label := ctx.Label(node)
 		indexCache[node] = int64(i + 1)

--- a/internal/graph/tgf.go
+++ b/internal/graph/tgf.go
@@ -15,7 +15,7 @@ type TGF struct {
 	label *template.Template
 }
 
-func (ctx *TGF) Label(p *pkggraph.Node) string {
+func (ctx *TGF) Label(p *pkggraph.GraphNode) string {
 	var labelText strings.Builder
 	err := ctx.label.Execute(&labelText, p)
 	if err != nil {
@@ -24,8 +24,8 @@ func (ctx *TGF) Label(p *pkggraph.Node) string {
 	return labelText.String()
 }
 
-func (ctx *TGF) Write(graph *pkggraph.Graph) {
-	indexCache := map[*pkggraph.Node]int64{}
+func (ctx *TGF) Write(graph *pkggraph.Graph) error {
+	indexCache := map[*pkggraph.GraphNode]int64{}
 	for i, node := range graph.Sorted {
 		label := ctx.Label(node)
 		indexCache[node] = int64(i + 1)
@@ -39,4 +39,6 @@ func (ctx *TGF) Write(graph *pkggraph.Graph) {
 			fmt.Fprintf(ctx.out, "%d %d\n", indexCache[node], indexCache[imp])
 		}
 	}
+
+	return nil
 }

--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -11,21 +11,21 @@ import (
 )
 
 type Graph struct {
-	Packages map[string]*GraphNode
-	Sorted   []*GraphNode
+	Packages map[string]*Node
+	Sorted   []*Node
 	stat.Stat
 }
 
-func (g *Graph) AddNode(n *GraphNode) {
+func (g *Graph) AddNode(n *Node) {
 	g.Packages[n.ID] = n
 	n.Graph = g
 }
 
-type GraphNode struct {
+type Node struct {
 	*packages.Package
 	Repo *vcs.RepoRoot
 
-	ImportsNodes []*GraphNode
+	ImportsNodes []*Node
 
 	// Stats about the current node.
 	stat.Stat
@@ -38,11 +38,11 @@ type GraphNode struct {
 	Graph  *Graph
 }
 
-func (n *GraphNode) Pkg() *packages.Package { return n.Package }
+func (n *Node) Pkg() *packages.Package { return n.Package }
 
 // From creates a new graph from a map of packages.
 func From(pkgs map[string]*packages.Package) *Graph {
-	g := &Graph{Packages: map[string]*GraphNode{}}
+	g := &Graph{Packages: map[string]*Node{}}
 
 	// Create the graph nodes.
 	for _, p := range pkgs {
@@ -94,8 +94,8 @@ func From(pkgs map[string]*packages.Package) *Graph {
 	return g
 }
 
-func LoadNode(p *packages.Package) *GraphNode {
-	node := &GraphNode{}
+func LoadNode(p *packages.Package) *Node {
+	node := &Node{}
 	node.Package = p
 
 	if repo, err := vcs.RepoRootForImportPath(p.PkgPath, false); err != nil {
@@ -111,7 +111,7 @@ func LoadNode(p *packages.Package) *GraphNode {
 	return node
 }
 
-func SortNodes(xs []*GraphNode) {
+func SortNodes(xs []*Node) {
 	sort.Slice(xs, func(i, k int) bool { return xs[i].ID < xs[k].ID })
 }
 
@@ -138,7 +138,7 @@ type flatNode struct {
 	Errors []error `json:",omitempty"`
 }
 
-func (p *GraphNode) MarshalJSON() ([]byte, error) {
+func (p *Node) MarshalJSON() ([]byte, error) {
 	flat := flatNode{
 		Stat:   p.Stat,
 		Up:     p.Up,

--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -11,21 +11,21 @@ import (
 )
 
 type Graph struct {
-	Packages map[string]*Node
-	Sorted   []*Node
+	Packages map[string]*GraphNode
+	Sorted   []*GraphNode
 	stat.Stat
 }
 
-func (g *Graph) AddNode(n *Node) {
+func (g *Graph) AddNode(n *GraphNode) {
 	g.Packages[n.ID] = n
 	n.Graph = g
 }
 
-type Node struct {
+type GraphNode struct {
 	*packages.Package
 	Repo *vcs.RepoRoot
 
-	ImportsNodes []*Node
+	ImportsNodes []*GraphNode
 
 	// Stats about the current node.
 	stat.Stat
@@ -38,11 +38,11 @@ type Node struct {
 	Graph  *Graph
 }
 
-func (n *Node) Pkg() *packages.Package { return n.Package }
+func (n *GraphNode) Pkg() *packages.Package { return n.Package }
 
 // From creates a new graph from a map of packages.
 func From(pkgs map[string]*packages.Package) *Graph {
-	g := &Graph{Packages: map[string]*Node{}}
+	g := &Graph{Packages: map[string]*GraphNode{}}
 
 	// Create the graph nodes.
 	for _, p := range pkgs {
@@ -94,8 +94,8 @@ func From(pkgs map[string]*packages.Package) *Graph {
 	return g
 }
 
-func LoadNode(p *packages.Package) *Node {
-	node := &Node{}
+func LoadNode(p *packages.Package) *GraphNode {
+	node := &GraphNode{}
 	node.Package = p
 
 	if repo, err := vcs.RepoRootForImportPath(p.PkgPath, false); err != nil {
@@ -111,7 +111,7 @@ func LoadNode(p *packages.Package) *Node {
 	return node
 }
 
-func SortNodes(xs []*Node) {
+func SortNodes(xs []*GraphNode) {
 	sort.Slice(xs, func(i, k int) bool { return xs[i].ID < xs[k].ID })
 }
 
@@ -138,7 +138,7 @@ type flatNode struct {
 	Errors []error `json:",omitempty"`
 }
 
-func (p *Node) MarshalJSON() ([]byte, error) {
+func (p *GraphNode) MarshalJSON() ([]byte, error) {
 	flat := flatNode{
 		Stat:   p.Stat,
 		Up:     p.Up,

--- a/internal/pkggraph/tree.go
+++ b/internal/pkggraph/tree.go
@@ -14,11 +14,40 @@ type Tree struct {
 
 	Parent   *Tree
 	Children []*Tree
+
+	strat Strategy
+}
+
+type Strategy interface {
+	Layers(pkg *Node) []string
+}
+
+type PathStrategy struct{}
+
+func (s PathStrategy) Layers(pkg *Node) []string {
+	return strings.Split(pkg.PkgPath, "/")
+}
+
+type RepoStrategy struct{}
+
+func (s RepoStrategy) Layers(pkg *Node) []string {
+	if pkg.Repo == nil {
+		return strings.Split(pkg.PkgPath, "/")
+	}
+
+	ls := []string{pkg.Repo.Root}
+
+	suffix := strings.TrimPrefix(strings.TrimPrefix(pkg.PkgPath, pkg.Repo.Root), "/")
+	if suffix != "" {
+		ls = append(ls, suffix)
+	}
+
+	return ls
 }
 
 // Tree returns Node tree.
-func (graph *Graph) Tree() *Tree {
-	tree := NewTree(nil, "")
+func (graph *Graph) Tree(strat Strategy) *Tree {
+	tree := NewTree(nil, "", strat)
 	for _, pkg := range graph.Sorted {
 		tree.Add(pkg)
 	}
@@ -26,16 +55,18 @@ func (graph *Graph) Tree() *Tree {
 	return tree
 }
 
-func NewTree(parent *Tree, path string) *Tree {
+func NewTree(parent *Tree, path string, strat Strategy) *Tree {
 	return &Tree{
 		Path:   path,
 		Child:  map[string]*Tree{},
 		Parent: parent,
+		strat:  strat,
 	}
 }
 
 func (tree *Tree) Add(pkg *Node) {
-	tree.Insert([]string{}, strings.Split(pkg.PkgPath, "/"), pkg)
+	layers := tree.strat.Layers(pkg)
+	tree.Insert([]string{}, layers, pkg)
 }
 
 func (tree *Tree) Insert(prefix, suffix []string, pkg *Node) {
@@ -47,7 +78,7 @@ func (tree *Tree) Insert(prefix, suffix []string, pkg *Node) {
 	childPrefix := append(prefix, suffix[0])
 	child, hasChild := tree.Child[suffix[0]]
 	if !hasChild {
-		child = NewTree(tree, path.Join(childPrefix...))
+		child = NewTree(tree, path.Join(childPrefix...), tree.strat)
 		tree.Child[suffix[0]] = child
 		tree.Children = append(tree.Children, child)
 	}

--- a/internal/pkggraph/tree.go
+++ b/internal/pkggraph/tree.go
@@ -1,117 +1,268 @@
 package pkggraph
 
 import (
-	"path"
+	"fmt"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/vcs"
 )
 
+func (g *Graph) Tree() (*Tree, error) {
+	goModCachePath, err := goModCache()
+	if err != nil {
+		return nil, err
+	}
+
+	t := Tree{
+		Repos: make(map[string]*Repo),
+	}
+	for _, n := range g.Sorted {
+		repo := t.NodeRepo(n)
+
+		if n.Module != nil {
+			mod := repo.NodeModule(n, goModCachePath)
+			mod.NodePackage(n)
+		} else {
+			repo.NodePackage(n)
+		}
+	}
+
+	t.Walk(func(tn TreeNode) {
+		if s, ok := tn.(interface{ Sort() }); ok {
+			s.Sort()
+		}
+	})
+
+	return &t, nil
+}
+
+type TreeNode interface {
+	Path() string
+	Package() *TreePackage
+	VisitChildren(func(TreeNode))
+}
+
 type Tree struct {
-	Path    string
-	Package *Node
-
-	Child map[string]*Tree
-
-	Parent   *Tree
-	Children []*Tree
-
-	strat Strategy
+	Repos       map[string]*Repo
+	sortedRepos []string
 }
 
-type Strategy interface {
-	Layers(pkg *Node) []string
+func (t *Tree) Path() string {
+	return ""
 }
 
-type PathStrategy struct{}
-
-func (s PathStrategy) Layers(pkg *Node) []string {
-	return strings.Split(pkg.PkgPath, "/")
+func (t *Tree) Package() *TreePackage {
+	return nil
 }
 
-type RepoStrategy struct{}
-
-func (s RepoStrategy) Layers(pkg *Node) []string {
-	if pkg.Repo == nil {
-		return strings.Split(pkg.PkgPath, "/")
-	}
-
-	ls := []string{pkg.Repo.Root}
-
-	suffix := strings.TrimPrefix(strings.TrimPrefix(pkg.PkgPath, pkg.Repo.Root), "/")
-	if suffix != "" {
-		ls = append(ls, suffix)
-	}
-
-	return ls
-}
-
-// Tree returns Node tree.
-func (graph *Graph) Tree(strat Strategy) *Tree {
-	tree := NewTree(nil, "", strat)
-	for _, pkg := range graph.Sorted {
-		tree.Add(pkg)
-	}
-	tree.Sort()
-	return tree
-}
-
-func NewTree(parent *Tree, path string, strat Strategy) *Tree {
-	return &Tree{
-		Path:   path,
-		Child:  map[string]*Tree{},
-		Parent: parent,
-		strat:  strat,
-	}
-}
-
-func (tree *Tree) Add(pkg *Node) {
-	layers := tree.strat.Layers(pkg)
-	tree.Insert([]string{}, layers, pkg)
-}
-
-func (tree *Tree) Insert(prefix, suffix []string, pkg *Node) {
-	if len(suffix) == 0 {
-		tree.Package = pkg
-		return
-	}
-
-	childPrefix := append(prefix, suffix[0])
-	child, hasChild := tree.Child[suffix[0]]
-	if !hasChild {
-		child = NewTree(tree, path.Join(childPrefix...), tree.strat)
-		tree.Child[suffix[0]] = child
-		tree.Children = append(tree.Children, child)
-	}
-
-	child.Insert(childPrefix, suffix[1:], pkg)
-}
-
-func (tree *Tree) Walk(fn func(tree *Tree)) {
-	fn(tree)
-	for _, child := range tree.Children {
-		child.Walk(fn)
-	}
-}
-
-func (tree *Tree) HasParent(parent *Tree) bool {
-	return strings.HasPrefix(tree.Path, parent.Path+"/")
-}
-
-func (tree *Tree) LookupTable() map[*Node]*Tree {
-	table := map[*Node]*Tree{}
-	tree.Walk(func(x *Tree) {
-		if x.Package != nil {
-			table[x.Package] = x
+func (t *Tree) LookupTable() map[*GraphNode]*TreePackage {
+	table := map[*GraphNode]*TreePackage{}
+	t.Walk(func(tn TreeNode) {
+		if pkg := tn.Package(); pkg != nil {
+			table[pkg.GraphNode] = pkg
 		}
 	})
 	return table
 }
 
-func (tree *Tree) Sort() {
-	tree.Walk(func(x *Tree) {
-		sort.Slice(x.Children, func(i, k int) bool {
-			left, right := x.Children[i], x.Children[k]
-			return left.Path < right.Path
-		})
+func (t *Tree) NodeRepo(n *GraphNode) *Repo {
+	repo, ok := t.Repos[n.Repo.Root]
+	if !ok {
+		repo = &Repo{
+			Root:    n.Repo,
+			Modules: make(map[string]*Module),
+		}
+		t.Repos[n.Repo.Root] = repo
+		t.sortedRepos = append(t.sortedRepos, n.Repo.Root)
+	}
+	return repo
+}
+
+func (t *Tree) Walk(fn func(TreeNode)) {
+	fn(t)
+
+	var visit func(TreeNode)
+	visit = func(tn TreeNode) {
+		fn(tn)
+		tn.VisitChildren(visit)
+	}
+	t.VisitChildren(visit)
+}
+
+func (t *Tree) VisitChildren(fn func(TreeNode)) {
+	for _, rp := range t.sortedRepos {
+		fn(t.Repos[rp])
+	}
+}
+
+func (t *Tree) Sort() {
+	sort.Strings(t.sortedRepos)
+}
+
+type Repo struct {
+	Root *vcs.RepoRoot
+
+	Modules    map[string]*Module
+	sortedMods []string
+
+	Pkgs       map[string]*TreePackage
+	sortedPkgs []string
+}
+
+func (r *Repo) Path() string {
+	return r.Root.Root
+}
+
+func (r *Repo) Package() *TreePackage {
+	return nil
+}
+
+func (r *Repo) SameAsOnlyModule() bool {
+	if len(r.Modules) != 1 {
+		return false
+	}
+	mod := r.Modules[r.sortedMods[0]]
+	prefix, pathMajor, ok := module.SplitPathVersion(mod.Mod.Path)
+	if !ok || r.Path() != prefix {
+		return false
+	}
+	if pathMajor == "" || mod.Local {
+		// Local modules will not have a version, assume it is the same without
+		// checking the major version matches.
+		return true
+	}
+	return module.CheckPathMajor(mod.Mod.Version, pathMajor) == nil
+}
+
+func (r *Repo) NodeModule(n *GraphNode, goModCachePath string) *Module {
+	mod, ok := r.Modules[n.Module.Path]
+	if !ok {
+		mod = &Module{
+			Parent: r,
+			Mod:    n.Module,
+			Pkgs:   make(map[string]*TreePackage),
+		}
+		if n.Module.Replace == nil {
+			if rp, err := filepath.Rel(goModCachePath, n.Module.Dir); err == nil {
+				// If the module is in the module cache its path relative to GOMODCACHE
+				// will not start with "..". If it does, then it is outside the
+				// GOMODCACHE and is likely a local copy of the module.
+				mod.Local = strings.HasPrefix(rp, "..")
+			}
+		}
+		r.Modules[n.Module.Path] = mod
+		r.sortedMods = append(r.sortedMods, n.Module.Path)
+	}
+	return mod
+}
+
+func (r *Repo) NodePackage(n *GraphNode) *TreePackage {
+	pkg, ok := r.Pkgs[n.PkgPath]
+	if !ok {
+		pkg = &TreePackage{
+			Parent:    r,
+			GraphNode: n,
+		}
+		r.Pkgs[n.PkgPath] = pkg
+		r.sortedPkgs = append(r.sortedPkgs, n.PkgPath)
+	}
+	return pkg
+}
+
+func (r *Repo) VisitChildren(fn func(TreeNode)) {
+	for _, mp := range r.sortedMods {
+		fn(r.Modules[mp])
+	}
+
+	for _, pp := range r.sortedPkgs {
+		fn(r.Pkgs[pp])
+	}
+}
+
+func (r *Repo) Sort() {
+	sort.Strings(r.sortedMods)
+	sort.Strings(r.sortedPkgs)
+}
+
+type Module struct {
+	Parent *Repo
+
+	Mod   *packages.Module
+	Local bool
+
+	Pkgs       map[string]*TreePackage
+	sortedPkgs []string
+}
+
+func (m *Module) Path() string {
+	return m.Mod.Path
+}
+
+func (m *Module) Package() *TreePackage {
+	return nil
+}
+
+func (m *Module) NodePackage(n *GraphNode) *TreePackage {
+	pkg, ok := m.Pkgs[n.PkgPath]
+	if !ok {
+		pkg = &TreePackage{
+			Parent:    m,
+			GraphNode: n,
+		}
+		m.Pkgs[n.PkgPath] = pkg
+		m.sortedPkgs = append(m.sortedPkgs, n.PkgPath)
+	}
+	return pkg
+}
+
+func (m *Module) VisitChildren(fn func(TreeNode)) {
+	for _, pp := range m.sortedPkgs {
+		fn(m.Pkgs[pp])
+	}
+}
+
+func (m *Module) Sort() {
+	sort.Strings(m.sortedPkgs)
+}
+
+type TreePackage struct {
+	Parent    TreeNode
+	GraphNode *GraphNode
+}
+
+func (p *TreePackage) Path() string {
+	return p.GraphNode.PkgPath
+}
+
+func (p *TreePackage) Package() *TreePackage {
+	return p
+}
+
+func (p *TreePackage) OnlyChild() bool {
+	count := 0
+	p.Parent.VisitChildren(func(TreeNode) {
+		count++
 	})
+	return count == 1
+}
+
+func (p *TreePackage) VisitChildren(_ func(TreeNode)) {}
+
+func goModCache() (string, error) {
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	out, err := cmd.Output()
+	switch err := err.(type) {
+	case *exec.ExitError:
+		return "", fmt.Errorf("failed to determine GOMODCACHE: %s", err.Stderr)
+	default:
+		return "", fmt.Errorf("failed to determine GOMODCACHE: %s", err)
+	case nil:
+		// just continue
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/pkgset/calc.go
+++ b/internal/pkgset/calc.go
@@ -10,7 +10,9 @@ import (
 	"github.com/loov/goda/internal/pkgset/ast"
 )
 
-func Parse(ctx context.Context, expr []string) (ast.Expr, error) {
+// Parse converts the expression represented by the expr strings into an AST
+// representation.
+func Parse(_ context.Context, expr []string) (ast.Expr, error) {
 	tokens, err := ast.Tokenize(strings.Join(expr, " "))
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize: %v", err)
@@ -24,6 +26,7 @@ func Parse(ctx context.Context, expr []string) (ast.Expr, error) {
 	return root, nil
 }
 
+// Calc parses expr and computes the set of packages it describes.
 func Calc(parentContext context.Context, expr []string) (Set, error) {
 	if len(expr) == 0 {
 		expr = []string{"."}

--- a/internal/pkgset/context.go
+++ b/internal/pkgset/context.go
@@ -128,6 +128,7 @@ func (strs Strings) Clone() Strings {
 	return append(Strings{}, strs...)
 }
 
+// KeyValue parses s into a key and value.
 func KeyValue(s string) (string, string) {
 	p := strings.LastIndexByte(s, '=')
 	if p < 0 {

--- a/internal/pkgset/set.go
+++ b/internal/pkgset/set.go
@@ -298,14 +298,14 @@ func Main(a Set) Set {
 func Test(a Set) Set {
 	rs := Set{}
 	for pid, pkg := range a {
-		if isTestPkg(pkg) {
+		if IsTestPkg(pkg) {
 			rs[pid] = pkg
 		}
 	}
 	return rs
 }
 
-func isTestPkg(pkg *packages.Package) bool {
+func IsTestPkg(pkg *packages.Package) bool {
 	return strings.HasSuffix(pkg.ID, ".test") ||
 		strings.HasSuffix(pkg.ID, "_test") ||
 		strings.HasSuffix(pkg.ID, ".test]")


### PR DESCRIPTION
I don't find the clusters chosen by `goda -cluster` map to concepts in Go. I think clustering based on repository and module membership provides a more useful visualization. Here's a rough draft of some changes to make `goda -cluster` work that way. Is this something you would consider adding to goda if it was polished up a bit more?