### PR TITLE
#62 Only add node if it doesn't contain errors

### DIFF
--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -100,6 +100,11 @@ func LoadNode(p *packages.Package) *Node {
 
 	if repo, err := vcs.RepoRootForImportPath(p.PkgPath, false); err != nil {
 		node.Errors = append(node.Errors, err)
+		node.Repo = &vcs.RepoRoot{
+			VCS:  &vcs.Cmd{},
+			Repo: p.PkgPath, // maybe it's possible to use `PkgPath` here instead or find one from `p.Module.???`
+			Root: p.PkgPath,
+		}
 	} else {
 		node.Repo = repo
 	}

--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -47,11 +47,9 @@ func From(pkgs map[string]*packages.Package) *Graph {
 	// Create the graph nodes.
 	for _, p := range pkgs {
 		n := LoadNode(p)
-		if len(n.Errors) == 0 {
-			g.Sorted = append(g.Sorted, n)
-			g.AddNode(n)
-			g.Stat.Add(n.Stat)
-		}
+		g.Sorted = append(g.Sorted, n)
+		g.AddNode(n)
+		g.Stat.Add(n.Stat)
 	}
 	SortNodes(g.Sorted)
 

--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -47,9 +47,11 @@ func From(pkgs map[string]*packages.Package) *Graph {
 	// Create the graph nodes.
 	for _, p := range pkgs {
 		n := LoadNode(p)
-		g.Sorted = append(g.Sorted, n)
-		g.AddNode(n)
-		g.Stat.Add(n.Stat)
+		if len(n.Errors) == 0 {
+			g.Sorted = append(g.Sorted, n)
+			g.AddNode(n)
+			g.Stat.Add(n.Stat)
+		}
 	}
 	SortNodes(g.Sorted)
 


### PR DESCRIPTION
Thanks for the great tool.

I did run across a null pointer dereference error when attempting to create a graph with the -cluster command, as described by someone else in #62 

I noticed that when LoadNode() is called, it sets an error if the repo cannot be loaded. If the error is set, it means the repo is *not* set, so anything attempting to access the node repo is then crashing. Rather than checking for nil values in specific places, I opted to no longer process that node at all.