### PR TITLE
#62 Provide default value when node repo fails to resolve

### DIFF
--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -100,6 +100,11 @@ func LoadNode(p *packages.Package) *Node {
 
 	if repo, err := vcs.RepoRootForImportPath(p.PkgPath, false); err != nil {
 		node.Errors = append(node.Errors, err)
+		node.Repo = &vcs.RepoRoot{
+			VCS:  &vcs.Cmd{},
+			Repo: p.PkgPath, // maybe it's possible to use `PkgPath` here instead or find one from `p.Module.???`
+			Root: p.PkgPath,
+		}
 	} else {
 		node.Repo = repo
 	}

--- a/internal/pkggraph/graph.go
+++ b/internal/pkggraph/graph.go
@@ -102,7 +102,7 @@ func LoadNode(p *packages.Package) *Node {
 		node.Errors = append(node.Errors, err)
 		node.Repo = &vcs.RepoRoot{
 			VCS:  &vcs.Cmd{},
-			Repo: p.PkgPath, // maybe it's possible to use `PkgPath` here instead or find one from `p.Module.???`
+			Repo: p.PkgPath,
 			Root: p.PkgPath,
 		}
 	} else {


### PR DESCRIPTION
Sorry, I messed up the previous PR #63 

I have made the fix suggested by @egonelbre - it now creates a default node.Repo struct value if error occurs.

I will re-add the repo code here for testing:

```
package main

import (
	"gorm.io/gorm/logger"
)

type Writer struct {
}

func (w Writer) Printf(format string, v ...interface{}) {
}

// main function
func main() {
	_ = logger.New(
		Writer{}, // io writer
		logger.Config{},
	)
}
```